### PR TITLE
Use django FormView rather than a view function

### DIFF
--- a/iris/views.py
+++ b/iris/views.py
@@ -1,52 +1,62 @@
-from django.shortcuts import render
-from .forms import ModelForm
-from .models import Predictions
 import pickle
 
+from django.shortcuts import render
+from django.views.generic import FormView
+from .forms import ModelForm
+from .models import Predictions
 
-def predict_model(request):
-    # if this is a POST request we need to process the form data
-    if request.method == 'POST':
-        # create a form instance and populate it with data from the request:
-        form = ModelForm(request.POST)
-        # check whether it's valid:
-        if form.is_valid():
-            # process the data in form.cleaned_data as required
-            sepal_length = form.cleaned_data['sepal_length']
-            sepal_width = form.cleaned_data['sepal_width']
-            petal_length = form.cleaned_data['petal_length']
-            petal_width = form.cleaned_data['petal_width']
 
-            # Run new features through ML model
-            model_features = [
-                [sepal_length, sepal_width, petal_length, petal_width]]
-            loaded_model = pickle.load(
-                open("ml_model/iris_model.pkl", 'rb'))
-            prediction = loaded_model.predict(model_features)[0]
+class PredictionView(FormView):
+    template_name = 'home.html'
+    form_class = ModelForm
+    success_url = '/'
 
-            prediction_dict = [{'name': 'setosa',
-                                'img': 'https://alchetron.com/cdn/iris-setosa-0ab3145a-68f2-41ca-a529-c02fa2f5b02-resize-750.jpeg'},
-                               {'name': 'versicolor',
-                                'img': 'https://wiki.irises.org/pub/Spec/SpecVersicolor/iversicolor07.jpg'},
-                               {'name': 'virginica',
-                                'img': 'https://www.gardenia.net/storage/app/public/uploads/images/detail/xUM027N8JI22aQPImPoH3NtIMpXkm89KAIKuvTMB.jpeg'}]
+    def form_valid(self, form):
+        # process the data in form.cleaned_data as required
+        sepal_length = form.cleaned_data['sepal_length']
+        sepal_width = form.cleaned_data['sepal_width']
+        petal_length = form.cleaned_data['petal_length']
+        petal_width = form.cleaned_data['petal_width']
 
-            prediction_name = prediction_dict[prediction]['name']
-            prediction_img = prediction_dict[prediction]['img']
+        # Run new features through ML model
+        model_features = [[sepal_length, sepal_width, petal_length, petal_width]]
+        loaded_model = pickle.load(open('ml_model/iris_model.pkl', 'rb'))
+        prediction = loaded_model.predict(model_features)[0]
 
-            # Save prediction to database Predictions table
-            Predictions.objects.create(sepal_length=sepal_length,
-                                       sepal_width=sepal_width,
-                                       petal_length=petal_length,
-                                       petal_width=petal_width,
-                                       prediction=prediction_name)
+        prediction_dict = [
+            {
+                'name': 'setosa',
+                'img': 'https://alchetron.com/cdn/iris-setosa-0ab3145a-68f2-41ca-a529-c02fa2f5b02-resize-750.jpeg',
+            },
+            {
+                'name': 'versicolor',
+                'img': 'https://wiki.irises.org/pub/Spec/SpecVersicolor/iversicolor07.jpg',
+            },
+            {
+                'name': 'virginica',
+                'img': 'https://www.gardenia.net/storage/app/public/uploads/images/detail/xUM027N8JI22aQPImPoH3NtIMpXkm89KAIKuvTMB.jpeg',
+            },
+        ]
 
-            return render(request, 'home.html', {'form': form, 'prediction': prediction,
-                                                 'prediction_name': prediction_name,
-                                                 'prediction_img': prediction_img})
+        prediction_name = prediction_dict[prediction]['name']
+        prediction_img = prediction_dict[prediction]['img']
 
-    # if a GET (or any other method) we'll create a blank form
-    else:
-        form = ModelForm()
+        # Save prediction to database Predictions table
+        Predictions.objects.create(
+            sepal_length=sepal_length,
+            sepal_width=sepal_width,
+            petal_length=petal_length,
+            petal_width=petal_width,
+            prediction=prediction_name,
+        )
 
-    return render(request, 'home.html', {'form': form})
+        return render(
+            self.request,
+            'home.html',
+            {
+                'form': form,
+                'prediction': prediction,
+                'prediction_name': prediction_name,
+                'prediction_img': prediction_img,
+            },
+        )

--- a/mysite/urls.py
+++ b/mysite/urls.py
@@ -18,6 +18,6 @@ from django.urls import path
 from iris import views
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
-    path('', views.predict_model, name='predict_model'),
+    path("admin/", admin.site.urls),
+    path("", views.PredictionView.as_view(), name="predict_model"),
 ]


### PR DESCRIPTION
# Description
This PR refactors the view function used to create a prediction to a [FormView](https://docs.djangoproject.com/en/3.1/ref/class-based-views/generic-editing/#formview). FormViews reduce the unit test burden by handling common form handling tasks behind the scenes.

Though the git diff appears significant, the logic within the view function was not changed, only the code around it.

Since this FormView creates a model entity on a POST, the necessary code can be reduced further by refactoring the view to use [Model Forms](https://docs.djangoproject.com/en/3.1/topics/class-based-views/generic-editing/#model-forms). These classes further reduce the unit testing burden by encapsulating the creation of models within Django generic classes.

# How to test
Everything should work as normal, with no change in functionality
